### PR TITLE
refactor(standards): add standards and update the code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 # JS Belgrade website
 
-[![Build Status](https://semaphoreci.com/api/v1/projects/08ef7fe0-254f-4121-b1f8-2d83ec6cc5e9/538747/badge.svg)](https://semaphoreci.com/feroc1ty/website-2)
+[![Build Status](https://semaphoreci.com/api/v1/projects/08ef7fe0-254f-4121-b1f8-2d83ec6cc5e9/538747/badge.svg)](https://semaphoreci.com/feroc1ty/website-2)  
+[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+
 
 New website for JSBelgrade.org
 

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,78 +1,84 @@
 #!/usr/bin/env node
 
-'use strict';
-const path = require('path');
-const Metalsmith = require('metalsmith');
-const layouts = require('metalsmith-layouts');
-const markdown = require('metalsmith-markdown');
-const permalinks = require('metalsmith-permalinks');
-const metalsmithPrism = require('metalsmith-prism');
-const collections = require('metalsmith-collections');
-const feed = require('metalsmith-feed');
-const mapHandlebarsPartials = require('../scripts/mapHandlebarsPartials');
-const siteInfo = require('../siteInfo');
-const ncp = require('ncp');
-const dir = path.join(__dirname, '..');
+'use strict'
 
-function build(done) {
+const path = require('path')
+const Metalsmith = require('metalsmith')
+const layouts = require('metalsmith-layouts')
+const markdown = require('metalsmith-markdown')
+const permalinks = require('metalsmith-permalinks')
+const metalsmithPrism = require('metalsmith-prism')
+const collections = require('metalsmith-collections')
+const feed = require('metalsmith-feed')
+const mapHandlebarsPartials = require('../scripts/mapHandlebarsPartials')
+const siteInfo = require('../siteInfo')
+const ncp = require('ncp')
+const dir = path.join(__dirname, '..')
 
-    const metalsmith = Metalsmith(dir);
+function build (done) {
+  const metalsmith = Metalsmith(dir)
 
-    metalsmith.metadata({site: siteInfo});
+  metalsmith.metadata({
+    site: siteInfo
+  })
 
-     metalsmith
-        .source(path.join(dir, 'content'))
-        .use(collections({
-            blog : {
-                pattern: 'blog/**/*.md',
-                sortBy: 'date',
-                reverse: true,
-                refer: false
-            },
-        }))
-        .use(feed({
-            collection: 'blog'
-        }))
-        .use(markdown({
-            langPrefix: 'language-'
-        }))
-        .use(metalsmithPrism())
-        .use(permalinks({
-            relative: false
-        }))
-        .use(layouts({
-            engine: 'handlebars',
-            pattern: '**/*.html',
-            partials: mapHandlebarsPartials(metalsmith, 'layouts', 'partials'),
-            helpers: {
-                excerpt: require('../scripts/helpers/excerpt'),
-                moment: require('../scripts/helpers/moment'),
-            }
-        }))
-        .destination(path.join(dir, 'dist'));
+  metalsmith
+    .source(path.join(dir, 'content'))
+      .use(collections({
+        blog: {
+          pattern: 'blog/**/*.md',
+          sortBy: 'date',
+          reverse: true,
+          refer: false
+        }
+      }))
+      .use(feed({
+        collection: 'blog'
+      }))
+      .use(markdown({
+        langPrefix: 'language-'
+      }))
+      .use(metalsmithPrism())
+      .use(permalinks({
+        relative: false
+      }))
+      .use(layouts({
+        engine: 'handlebars',
+        pattern: '**/*.html',
+        partials: mapHandlebarsPartials(metalsmith, 'layouts', 'partials'),
+        helpers: {
+          excerpt: require('../scripts/helpers/excerpt'),
+          moment: require('../scripts/helpers/moment')
+        }
+      }))
+      .destination(path.join(dir, 'dist'))
 
-        metalsmith.build(function (err) {
-            if (err) { throw err; }
-            done && done();
-        });
+  metalsmith.build(function (err) {
+    if (err) {
+      throw err
+    }
+    done && done()
+  })
 }
 
-
-function copyStatic(done) {
-    ncp(path.join(dir, 'static'), path.join(dir, 'dist', 'static'), function(err) {
-        if (err) {
-            throw err
-        }
-        done && done();
-    });
+function copyStatic (done) {
+  ncp(path.join(dir, 'static'), path.join(dir, 'dist', 'static'), function (err) {
+    if (err) {
+      throw err
+    }
+    done && done()
+  })
 }
 
 var buildAndCopy = function (done) {
-    build(function(){
-        copyStatic(function() { done && done(); console.log('build done!') })
-    });
-};
+  build(function () {
+    copyStatic(function () {
+      done && done()
+      console.log('build done!')
+    })
+  })
+}
 
-buildAndCopy();
+buildAndCopy()
 
-module.exports = buildAndCopy;
+module.exports = buildAndCopy

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,49 +1,53 @@
 #!/usr/bin/env node
 
-'use strict';
+'use strict'
 
-const st = require('st');
-const http = require('http');
-const path = require('path');
-const dir = path.join(__dirname, '..');
-const chokidar = require('chokidar');
-const build = require('./build');
-function start() {
-    const mount = st({
-        path: path.join(dir, 'dist'),
-        cache: false,
-        index: 'index.html'
-    });
-    http.createServer(function (req, res) {
-        mount(req, res);
-    }).listen(8080, function () {
-        let url = 'http://localhost:8080';
-        console.log(`Serving static site at: ${url}`);
-        // Open browser url after 1.5s (it waits for everything to be built)
-        setTimeout(function() {
-            require("openurl").open(url)
-        }, 1500);
-    });
+const st = require('st')
+const http = require('http')
+const path = require('path')
+const dir = path.join(__dirname, '..')
+const chokidar = require('chokidar')
+const build = require('./build')
 
-    /** File Watches for Re-Builds **/
-    const opts = {
-        persistent: true,
-        ignoreInitial: true,
-        followSymlinks: true,
-        usePolling: true,
-        alwaysStat: false,
-        depth: undefined,
-        interval: 100,
-        ignorePermissionErrors: false,
-        atomic: true
-    };
+function start () {
+  const mount = st({
+    path: path.join(dir, 'dist'),
+    cache: false,
+    index: 'index.html'
+  })
 
+  http.createServer(function (req, res) {
+    mount(req, res)
+  }).listen(8080, function () {
+    let url = 'http://localhost:8080'
 
-    ['layouts', 'static', 'content'].forEach(function(folder) {
-        chokidar.watch(path.join(dir, folder), opts).on('change', function() {
-            console.log('files changed in', folder, 'building...');
-            build();
-        })
-    });
+    console.log(`Serving static site at: ${url}`)
+
+    // Open browser url after 1.5s (it waits for everything to be built)
+    setTimeout(function () {
+      require('openurl').open(url)
+    }, 1500)
+  })
+
+  /** File Watches for Re-Builds **/
+  const opts = {
+    persistent: true,
+    ignoreInitial: true,
+    followSymlinks: true,
+    usePolling: true,
+    alwaysStat: false,
+    depth: undefined,
+    interval: 100,
+    ignorePermissionErrors: false,
+    atomic: true
+  }
+
+  ;['layouts', 'static', 'content'].forEach(function (folder) {
+    chokidar.watch(path.join(dir, folder), opts).on('change', function () {
+      console.log('files changed in', folder, 'building...')
+      build()
+    })
+  })
 }
-start();
+
+start()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bin/build.js",
   "scripts": {
     "build": "./bin/build.js",
-    "start": "./bin/server.js"
+    "start": "standard --verbose | snazzy && ./bin/server.js"
   },
   "repository": {
     "type": "git",
@@ -33,5 +33,15 @@
     "ncp": "^2.0.0",
     "openurl": "^1.1.0",
     "st": "^0.5.5"
+  },
+  "devDependencies": {
+    "snazzy": "^2.0.1",
+    "standard": "^5.3.0"
+  },
+  "standard": {
+    "ignore": [
+      "static",
+      "scripts"
+    ]
   }
 }

--- a/siteInfo.js
+++ b/siteInfo.js
@@ -1,11 +1,11 @@
 module.exports = {
-    "title": "JS Belgrade",
-    "author": "JS Belgrade Community",
-    "url": "https://jsbelgrade.org",
-    "description": "JS Belgrade is JavaScript User Group from Belgrade, Serbia. Our goal is to connect Belgrade's JavaScript community through monthly meetups.",
-    "twitterHandler": "@JSBelgrade",
-    "twitter": "https://twitter.com/JSBelgrade",
-    "facebook": "https://www.facebook.com/jsbelgrade",
-    "slack": "http://slack.jsbelgrade.org/",
-    "github": "https://github.com/JSBelgrade"
-};
+  'title': 'JS Belgrade',
+  'author': 'JS Belgrade Community',
+  'url': 'https://jsbelgrade.org',
+  'description': 'JS Belgrade is JavaScript User Group from Belgrade, Serbia. Our goal is to connect Belgrade\'s JavaScript community through monthly meetups.',
+  'twitterHandler': '@JSBelgrade',
+  'twitter': 'https://twitter.com/JSBelgrade',
+  'facebook': 'https://www.facebook.com/jsbelgrade',
+  'slack': 'http://slack.jsbelgrade.org/',
+  'github': 'https://github.com/JSBelgrade'
+}


### PR DESCRIPTION
This commit is adding JS standards and editor config and refactoring scripts from bin folder and siteInfo.js to match those standards. It's also adding a check for standards when you run 'npm start' and badge to readme. This is not a best way to check if standards are ok, but it's a beginning.
